### PR TITLE
Added new API to suspend analyzer

### DIFF
--- a/AudioAnalyzer/AudioAnalyzer.cpp
+++ b/AudioAnalyzer/AudioAnalyzer.cpp
@@ -47,7 +47,8 @@ namespace AudioAnalyzer
 		m_bUseLogAmpScale(true),
 		m_bUseLogFScale(false),
 		m_vClampAmpLow(DirectX::XMVectorReplicate(-100.0f)),	// Clamp DB values between -100 and FLT_MAX
-		m_vClampAmpHigh(DirectX::XMVectorReplicate(FLT_MAX))
+		m_vClampAmpHigh(DirectX::XMVectorReplicate(FLT_MAX)),
+		m_bIsSuspended(false)
 	{
 
 	}
@@ -221,6 +222,26 @@ namespace AudioAnalyzer
 	STDMETHODIMP CAnalyzerEffect::put_IsLogAmplitudeScale(boolean bIsLogAmpScale)
 	{
 		m_bUseLogAmpScale = bIsLogAmpScale;
+		return S_OK;
+	}
+
+	STDMETHODIMP CAnalyzerEffect::get_IsSuspended(boolean * pbIsSuspended)
+	{
+		if (pbIsSuspended == nullptr)
+			return E_INVALIDARG;
+		*pbIsSuspended = m_bIsSuspended;
+		return S_OK;
+	}
+
+	STDMETHODIMP CAnalyzerEffect::put_IsSuspended(boolean bNewValue)
+	{
+		if (m_bIsSuspended != bNewValue)
+		{
+			if (bNewValue)
+				return Analyzer_Suspend();
+			else
+				return Analyzer_Resume();
+		}
 		return S_OK;
 	}
 
@@ -1227,6 +1248,16 @@ namespace AudioAnalyzer
 			m_AnalyzerOutput.front() = nullptr;
 			m_AnalyzerOutput.pop();
 		}
+		return S_OK;
+	}
+
+	HRESULT CAnalyzerEffect::Analyzer_Resume()
+	{
+		return S_OK;
+	}
+
+	HRESULT CAnalyzerEffect::Analyzer_Suspend()
+	{
 		return S_OK;
 	}
 

--- a/AudioAnalyzer/AudioAnalyzer.h
+++ b/AudioAnalyzer/AudioAnalyzer.h
@@ -29,6 +29,8 @@ namespace AudioAnalyzer
 		UINT32 m_FramesPerSecond;
 		UINT32 m_nChannels;
 
+		bool m_bIsSuspended;	// Is analyzer in a suspended state
+
 		const size_t cMaxOutputQueueSize = 600;	// Keep 10sec worth of data for 60fps output
 
 		buffers::ring_buffer<float, 960000> m_InputBuffer;	// Allocate input buffer for 10sec stereo data at 48k
@@ -80,6 +82,8 @@ namespace AudioAnalyzer
 		HRESULT Analyzer_Flush(); 
 		HRESULT Analyzer_CompactOutputQueue();
 		HRESULT Analyzer_FlushOutputQueue();
+		HRESULT Analyzer_Resume();
+		HRESULT Analyzer_Suspend();
 		HRESULT Analyzer_FFwdQueueTo(REFERENCE_TIME time, IMFSample **ppSample);
 		void Analyzer_ConvertToDb(DirectX::XMVECTOR *pvData, size_t nElements);	// Converts input values to db range
 
@@ -187,6 +191,8 @@ namespace AudioAnalyzer
 		STDMETHODIMP get_OutputElementsCount(unsigned long *pOutElements);
 		STDMETHODIMP get_IsLogAmplitudeScale(boolean *pbIsLogAmpScale);
 		STDMETHODIMP put_IsLogAmplitudeScale(boolean bIsLogAmpScale);
+		STDMETHODIMP get_IsSuspended(boolean *pbIsSuspended);
+		STDMETHODIMP put_IsSuspended(boolean bIsSuspended);
 
 #pragma endregion
 	};

--- a/AudioAnalyzer/AudioAnalyzer.idl
+++ b/AudioAnalyzer/AudioAnalyzer.idl
@@ -23,6 +23,8 @@ namespace AudioAnalyzer
 	[propget] HRESULT OutputElementsCount([out][retval] unsigned long *result);
 	[propget] HRESULT IsLogAmplitudeScale([out][retval] boolean *result);
 	[propput] HRESULT IsLogAmplitudeScale(boolean value);
+	[propget] HRESULT IsSuspended([out][retval] boolean *bIsSuspended);
+	[propput] HRESULT IsSuspended(boolean bIsSuspended);
 	};
 
 	[version(NTDDI_WIN10)]

--- a/AudioAnalyzer/AudioAnalyzer_h.h
+++ b/AudioAnalyzer/AudioAnalyzer_h.h
@@ -6,7 +6,7 @@
  /* File created by MIDL compiler version 8.01.0622 */
 /* at Mon Jan 18 19:14:07 2038
  */
-/* Compiler settings for C:\Users\tonuv\AppData\Local\Temp\AudioAnalyzer.idl-55a15377:
+/* Compiler settings for C:\Users\tonuv\AppData\Local\Temp\AudioAnalyzer.idl-bb4fb473:
     Oicf, W1, Zp8, env=Win64 (32b run), target_arch=AMD64 8.01.0622 
     protocol : dce , ms_ext, c_ext, robust
     error checks: allocation ref bounds_check enum stub_data 
@@ -159,6 +159,12 @@ EXTERN_C const IID IID___x_ABI_CAudioAnalyzer_CIAudioAnalyzer;
                 virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_IsLogAmplitudeScale( 
                     boolean value) = 0;
                 
+                virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_IsSuspended( 
+                    /* [out][retval] */ boolean *bIsSuspended) = 0;
+                
+                virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_IsSuspended( 
+                    boolean bIsSuspended) = 0;
+                
             };
 
             extern const __declspec(selectany) IID & IID_IAudioAnalyzer = __uuidof(IAudioAnalyzer);
@@ -247,6 +253,14 @@ EXTERN_C const IID IID___x_ABI_CAudioAnalyzer_CIAudioAnalyzer;
             __x_ABI_CAudioAnalyzer_CIAudioAnalyzer * This,
             boolean value);
         
+        /* [propget] */ HRESULT ( STDMETHODCALLTYPE *get_IsSuspended )( 
+            __x_ABI_CAudioAnalyzer_CIAudioAnalyzer * This,
+            /* [out][retval] */ boolean *bIsSuspended);
+        
+        /* [propput] */ HRESULT ( STDMETHODCALLTYPE *put_IsSuspended )( 
+            __x_ABI_CAudioAnalyzer_CIAudioAnalyzer * This,
+            boolean bIsSuspended);
+        
         END_INTERFACE
     } __x_ABI_CAudioAnalyzer_CIAudioAnalyzerVtbl;
 
@@ -312,6 +326,12 @@ EXTERN_C const IID IID___x_ABI_CAudioAnalyzer_CIAudioAnalyzer;
 
 #define __x_ABI_CAudioAnalyzer_CIAudioAnalyzer_put_IsLogAmplitudeScale(This,value)	\
     ( (This)->lpVtbl -> put_IsLogAmplitudeScale(This,value) ) 
+
+#define __x_ABI_CAudioAnalyzer_CIAudioAnalyzer_get_IsSuspended(This,bIsSuspended)	\
+    ( (This)->lpVtbl -> get_IsSuspended(This,bIsSuspended) ) 
+
+#define __x_ABI_CAudioAnalyzer_CIAudioAnalyzer_put_IsSuspended(This,bIsSuspended)	\
+    ( (This)->lpVtbl -> put_IsSuspended(This,bIsSuspended) ) 
 
 #endif /* COBJMACROS */
 


### PR DESCRIPTION
Functionalitiy is not yet there - to suspend processing set AudioAnalyzer.IsSuspended = true (and to resume set to false). Calls to GetFrame will return null until the processing catches up after resume.